### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -45,7 +45,7 @@ my $builder = $class->new(
 		'Git::Repository'      => 0,
 		'Test::Exception'      => 0,
 		'Test::FailWarnings'   => 0,
-		'Test::Git'            => 0,
+		'Test::Requires::Git'  => 1.005,
 		'Test::More'           => 0.94,
 	},
 	requires             =>

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,7 @@ WriteMakefile
   'VERSION_FROM' => 'lib/App/GitHooks/Plugin/RequireCommitMessage.pm',
   'PREREQ_PM' => {
                    'App::GitHooks' => '1.005001',
-                   'Test::Git' => 0,
+                   'Test::Requires::Git' => 1.005,
                    'Test::Exception' => 0,
                    'Capture::Tiny' => 0,
                    'Test::FailWarnings' => 0,

--- a/t/01-git_version.t
+++ b/t/01-git_version.t
@@ -4,11 +4,11 @@ use strict;
 use warnings;
 
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
-has_git();
+test_requires_git();
 
 plan( tests => 2 );
 

--- a/t/10-run.t
+++ b/t/10-run.t
@@ -7,7 +7,7 @@ use warnings;
 # Capture::Tiny.
 use Capture::Tiny;
 use Test::Exception;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 use App::GitHooks::Test qw( ok_add_files ok_setup_repository );
@@ -16,7 +16,7 @@ use App::GitHooks::Test qw( ok_add_files ok_setup_repository );
 ## no critic (RegularExpressions::RequireExtendedFormatting)
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 
 # List of tests to perform.
 my $files =
@@ -60,7 +60,7 @@ my $tests =
 ];
 
 # Bail out if Git isn't available.
-has_git();
+test_requires_git();
 plan( tests => scalar( @$tests ) );
 
 foreach my $test ( @$tests )


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
